### PR TITLE
"Implement flexible error checking with multiple options"

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This is a simple program that scrapes problems from the USA Computing Olympiad w
     Example:
     
     ```bash
-    python scraper.py "https://usaco.org/index.php?page=viewproblem2&cpid=810" --file "Test.md"
+    python scraper.py "https://usaco.org/index.php?page=viewproblem2&cpid=810" --file "Test"
     ```
 
 ## Using the USACO scraper file with the GUI

--- a/src/main.py
+++ b/src/main.py
@@ -27,10 +27,10 @@ class USACOProblemScraper(customtkinter.CTk):
             font=self.font
         )
         self.url_entry.pack(pady=3, padx=3, expand=True, fill=tkinter.BOTH)
-        self.url_entry.bind("<KeyRelease>", self._check_url_entry)
+        self.url_entry.bind("<KeyRelease>", self._check_entries)
 
         # Initialize file entry
-        self.file: str = "README.md"
+        self.file: str = "README"
         self.file_entry = customtkinter.CTkEntry(
             self.center_frame, 
             placeholder_text="File", 
@@ -38,7 +38,7 @@ class USACOProblemScraper(customtkinter.CTk):
         )
         self.file_entry.insert(tkinter.END, self.file)
         self.file_entry.pack(pady=3, padx=3, expand=True, fill=tkinter.BOTH)
-        self.file_entry.bind("<KeyRelease>", self._check_file_entry)
+        self.file_entry.bind("<KeyRelease>", self._check_entries)
 
         # Initialize the directory button
         self.directory_button = customtkinter.CTkButton(
@@ -79,30 +79,23 @@ class USACOProblemScraper(customtkinter.CTk):
         if choosen_directory:
             self.target_directory = choosen_directory
 
-    def _check_url_entry(self, event):
-        """Check the URL entry to enable the scrape button if the URL is valid. 
-        
-        Args:
-            event (tkinter.Event): The event that triggered the URL entry check
-        """
-        if self.url_entry.get().strip() and self.url_entry.get().strip().startswith("https://usaco.org/"):
-            self.scrape_button.configure(state=tkinter.NORMAL)
-        else:
-            self.scrape_button.configure(state=tkinter.DISABLED)
-
-    def _check_file_entry(self, event):
-        """Check the file entry to enable the scrape button if the file name is valid.
+    def _check_entries(self, event):
+        """Check the url and file entries to enable the scrape button if they are valid.
 
         Args:
-            event (tkinter.Event): The event that triggered the file entry check
+            event (tkinter.Event): The event that triggered the check
         """
+        url: str = self.url_entry.get().strip()
         file: str = self.file_entry.get().strip()
         invalid_chars: list[str] = ['/', '\\', ':', '*', '?', '"', '<', '>', '|']
-        if ('.' in file and not file.endswith('.md') or 
-        any(char in file for char in invalid_chars)):
-            self.scrape_button.configure(state=tkinter.DISABLED)
+        if (url.startswith("https://usaco.org/index.php?page=viewproblem") and
+        (not '.' in file or file.endswith('.md') and 
+        not any(char in file for char in invalid_chars))):
+            if self.scrape_button.cget('state') != tkinter.NORMAL:
+                self.scrape_button.configure(state=tkinter.NORMAL)
         else:
-            self.scrape_button.configure(state=tkinter.NORMAL)
+            if self.scrape_button.cget('state') != tkinter.DISABLED:
+                self.scrape_button.configure(state=tkinter.DISABLED)
 
     def _scrape_problem(self):
         """Scrape the USACO problem and write it to the target directory"""

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -1,7 +1,7 @@
 import requests, bs4, time, os, argparse
 
 class USACOProblem:
-	def __init__(self, url: str, file: str = "README.md", directory: str = os.getcwd()):
+	def __init__(self, url: str, file: str = "README", directory: str = os.getcwd()):
 		"""Scrapes a USACO problem and writes it to a markdown file.
 
 		Args:
@@ -9,6 +9,9 @@ class USACOProblem:
 			file (str, optional): File name to write the problem to. Defaults to "README.md".
 			directory (str, optional): Directory to write the file to. Defaults to workspace directory.
 		"""
+		self.USACO_WEBSITE: str = "https://usaco.org/"
+		if not url or not url.startswith(f"{self.USACO_WEBSITE}index.php?page=viewproblem"):
+			raise ValueError(f"URL must start with: {self.USACO_WEBSITE}index.php?page=viewproblem")
 		self.URL: str = url
 
 		if '.' in file and not file.endswith('.md'):
@@ -35,10 +38,10 @@ class USACOProblem:
 				time.sleep(attempts)
 				attempts += 1
 		if response is None:
-			raise requests.exceptions.ConnectionError("Connection error. Please check your internet connection.")
+			raise requests.exceptions.ConnectionError("Connection error. Please check your internet connection or the URL.")
 		self._soup = bs4.BeautifulSoup(response.content, 'html.parser')
 
-		self.CONTEST_URL = "https://usaco.org/" + self._soup.find('button')['onclick'].split('\'')[1]
+		self.CONTEST_URL = self.USACO_WEBSITE + self._soup.find('button')['onclick'].split('\'')[1]
 		self.CONTEST_TITLE: str = self._soup.find('h2').text.strip()
 		self.PROBLEM_TITLE: str = self._soup.find_all('h2')[1].text.strip()
 		self.division: str = self.CONTEST_TITLE.split(' ')[-1]
@@ -132,9 +135,23 @@ class USACOProblem:
 
 if __name__ == '__main__':
 	parser = argparse.ArgumentParser()
-	parser.add_argument('url', type=str, help='URL of the USACO problem')
-	parser.add_argument('--file', type=str, help='File to write the problem to', default='README.md')
-	parser.add_argument('--directory', type=str, help='Directory to write the file to', default=os.getcwd())
+	parser.add_argument(
+		'url', 
+		type=str, 
+		help='URL of the USACO problem'
+	)
+	parser.add_argument(
+		'--file', 
+		type=str, 
+		help='File to write the problem to', 
+		default='README'
+	)
+	parser.add_argument(
+		'--directory', 
+		type=str, 
+		help='Directory to write the file to', 
+		default=os.getcwd()
+	)
 	args = parser.parse_args()
 
 	usaco_problem = USACOProblem(url=args.url, file=args.file)


### PR DESCRIPTION
This pull request implements flexible error checking with multiple options. It adds error checking functionality to the URL and file entries in the GUI, enabling the scrape button only when the entries are valid. The URL entry is checked to ensure it starts with "https://usaco.org/index.php?page=viewproblem", and the file entry is checked to ensure it doesn't contain invalid characters and ends with ".md". This improves the user experience by preventing the user from initiating a scrape with invalid inputs.